### PR TITLE
Switch to a table-based layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Here are possible keys you can pass through the options parameter:
 * `beforeName`: Text to place above the left side of the diff.
 * `afterName`: Text to place above the right side of the diff.
 * `contextSize`: Minimum number of lines of context to show around each diff hunk. (default: _10_).
+* `wordWrap`: By default, code will go all the way to the right margin of the diff. If there are 60 characters of space, character 61 will wrap to the next line, even mid-word. To wrap at word boundaries instead, set this option.
 
 Here's an example usage with a filled-out options parameter:
 
@@ -54,7 +55,8 @@ $('#diffview').append(
         language: 'python',
         beforeName: 'oldfilename.py',
         afterName: 'newfilename.py',
-        contextSize: 8
+        contextSize: 8,
+        wordWrap: true
     }));
 ```
 

--- a/codediff.css
+++ b/codediff.css
@@ -2,13 +2,26 @@
   box-sizing: border-box;
 }
 
-.diff-column-width {
-  max-width: 101ch;
-  min-width: 40ch;
-  width: 100%;
+div.diff {
+  max-width: 100%;
+  display: table;
 }
-.diff-column {
-  max-width: 50%;
+
+table.diff {
+  width: 100%;
+  border-spacing: 0;
+}
+
+td.code {
+  /* this is the max width of each column of code. */
+  /* for table cells, `width` behaves more like `max-width`. */
+  width: 61ch;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+table.diff td {
+  vertical-align: top;
 }
 
 .diff-header, .line-no-header {
@@ -17,65 +30,27 @@
   padding: 2px;
 }
 
-.diff-line-no {
-  display: table;  /* shrink to fit longest line number */
-}
-.diff-left .diff-line-no {
-  float: left;
-}
-.diff-right .diff-line-no {
-  float: right;
-}
-.diff-remainder {
-  overflow: hidden;  /* see http://stackoverflow.com/questions/5540485/how-to-make-an-inline-block-element-fill-the-remainder-of-the-line */
-}
-
 .line-no {
   color: #999;
   background-color: #f7f7f7;
 }
 
-.diff-left .line-no {
+table.diff .line-no:first-child {
   border-right: 1px solid #ddd;
   text-align: right;
 }
-.diff-right .line-no {
+table.diff .line-no:last-child {
   border-left: 1px solid #ddd;
   text-align: left;
 }
-.diff-left.diff-column {
+table.diff td:nth-child(2) {
   border-right: 1px solid #ddd;
-}
-
-.diff-line-no, .diff-wrapper, .diff-column {
-  display: inline-block;
-  vertical-align: top;
-}
-
-.diff-wrapper {
-  overflow-x: auto;
-  overflow-y: hidden;  /* shouldn't happen, but we sometimes get a pixel. */
-}
-
-.diff-content {
-  display: table;  /* "expand to fit" */
-  min-width: 100%;
 }
 
 .line-no, .code {
   padding: 2px;
   height: 1.11em;
-  white-space: pre;
   font-family: monospace;
-}
-
-.diff {
-  white-space: nowrap;
-}
-
-.diff-wrapper, .diff-wrapper > div {
-  display: inline-block;
-  vertical-align: top;
 }
 
 .diff .delete {

--- a/codediff.css
+++ b/codediff.css
@@ -36,12 +36,14 @@ table.diff td {
   background-color: #f7f7f7;
 }
 .line-no:first-child {
-  background-image: linear-gradient(to left, #f7f7f7, #f7f7f7 3px, transparent, transparent 6px, #f7f7f7 6px),
-                    linear-gradient(#f7f7f7, #f7f7f7 1.4em, #aaa 1.4em);
+  background-image:
+      linear-gradient(to left, #f7f7f7, #f7f7f7 3px, transparent, transparent 6px, #f7f7f7 6px),
+      linear-gradient(#f7f7f7, #f7f7f7 1.4em, #aaa 1.4em);
 }
 .line-no:last-child {
-  background-image: linear-gradient(to right, #f7f7f7, #f7f7f7 3px, transparent, transparent 6px, #f7f7f7 6px),
-                    linear-gradient(#f7f7f7, #f7f7f7 1.4em, #aaa 1.4em);
+  background-image:
+      linear-gradient(to right, #f7f7f7, #f7f7f7 3px, transparent, transparent 6px, #f7f7f7 6px),
+      linear-gradient(#f7f7f7, #f7f7f7 1.4em, #aaa 1.4em);
 }
 
 table.diff .line-no:first-child {
@@ -60,6 +62,10 @@ table.diff td:nth-child(2) {
   padding: 2px;
   height: 1.11em;
   font-family: monospace;
+}
+.diff .skip {
+  text-align: center;
+  background: #f7f7f7;
 }
 
 .diff .delete {

--- a/codediff.css
+++ b/codediff.css
@@ -74,3 +74,49 @@ table.diff td:nth-child(2) {
 .diff-right-content .char-replace, .diff-right-content .char-insert {
   background-color: #cfc;
 }
+
+/* Single column selection */
+.selecting-left  td,
+.selecting-left  td *,
+.selecting-right td,
+.selecting-right td *
+{
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.selecting-left  td.line-no::selection,
+.selecting-left  td.line-no *::selection,
+.selecting-right td.line-no::selection,
+.selecting-right td.line-no *::selection,
+.selecting-left  td.after::selection,
+.selecting-left  td.after *::selection,
+.selecting-right td.before::selection,
+.selecting-right td.before *::selection
+{
+  background: transparent;
+}
+
+.selecting-left  td.line-no::-moz-selection,
+.selecting-left  td.line-no *::-moz-selection,
+.selecting-right td.line-no::-moz-selection,
+.selecting-right td.line-no *::-moz-selection,
+.selecting-left  td.after::-moz-selection,
+.selecting-left  td.after *::-moz-selection,
+.selecting-right td.before::-moz-selection,
+.selecting-right td.before *::-moz-selection
+{
+  background: transparent;
+}
+
+.selecting-left  td.before,
+.selecting-left  td.before *,
+.selecting-right td.after,
+.selecting-right td.after * {
+  -moz-user-select: text;
+  -webkit-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}

--- a/codediff.css
+++ b/codediff.css
@@ -30,9 +30,18 @@ table.diff td {
   padding: 2px;
 }
 
+/* Line numbers with thin vertical bars to indicate wrapped lines. */
 .line-no {
   color: #999;
   background-color: #f7f7f7;
+}
+.line-no:first-child {
+  background-image: linear-gradient(to left, #f7f7f7, #f7f7f7 3px, transparent, transparent 6px, #f7f7f7 6px),
+                    linear-gradient(#f7f7f7, #f7f7f7 1.4em, #aaa 1.4em);
+}
+.line-no:last-child {
+  background-image: linear-gradient(to right, #f7f7f7, #f7f7f7 3px, transparent, transparent 6px, #f7f7f7 6px),
+                    linear-gradient(#f7f7f7, #f7f7f7 1.4em, #aaa 1.4em);
 }
 
 table.diff .line-no:first-child {

--- a/codediff.css
+++ b/codediff.css
@@ -24,12 +24,6 @@ table.diff td {
   vertical-align: top;
 }
 
-.diff-header, .line-no-header {
-  font-weight: bold;
-  border-bottom: 1px solid #ddd;
-  padding: 2px;
-}
-
 /* Line numbers with thin vertical bars to indicate wrapped lines. */
 .line-no {
   color: #999;

--- a/codediff.css
+++ b/codediff.css
@@ -69,18 +69,18 @@ table.diff td:nth-child(2) {
   background-color: #efe;
 }
 
-.diff-left-content .replace {
+.before.replace {
   background-color: #fee;
 }
-.diff-right-content .replace {
+.after.replace {
   background-color: #efe;
 }
 
-.diff-left-content .char-replace, .diff-left-content .char-delete {
+.before .char-replace, .before .char-delete {
   background-color: #fcc;
 }
 
-.diff-right-content .char-replace, .diff-right-content .char-insert {
+.after .char-replace, .after .char-insert {
   background-color: #cfc;
 }
 

--- a/codediff.js
+++ b/codediff.js
@@ -98,13 +98,6 @@ differ.highlightText_ = function(text, opt_language) {
  * Attach event listeners, notably for the "show more" links.
  */
 differ.prototype.attachHandlers_ = function(el) {
-  // Synchronize horizontal scrolling.
-  var $wrapperDivs = $(el).find('.diff-wrapper');
-  $wrapperDivs.on('scroll', function(e) {
-    var otherDiv = $wrapperDivs.not(this).get(0);
-    otherDiv.scrollLeft = this.scrollLeft;
-  });
-
   var this_differ = this;
   $(el).on('click', '.skip a', function(e) {
     e.preventDefault();
@@ -115,30 +108,20 @@ differ.prototype.attachHandlers_ = function(el) {
     var beforeEnd = beforeIdx + jump;
     var afterEnd = afterIdx + jump;
     var change = "equal";
-    var newRows = [];
+    var newTrs = [];
     for (var i = 0; i < jump; i++) {
       var data = this_differ.buildRow_(beforeIdx, beforeEnd, afterIdx, afterEnd, change);
       beforeIdx = data.newBeforeIdx;
       afterIdx = data.newAfterIdx;
-      newRows.push(data.row);
+      var row = data.row;
+      var $tr = $('<tr>');
+      $tr.append(row[0], row[1], row[3], row[2]);
+      newTrs.push($tr.get(0));
     }
-
-    console.log(newRows);
 
     // Replace the "skip" rows with real code.
-    var $lefts = $(this).closest('.diff').find('.diff-left').find('[line-no=' + (1+skipData.beforeStartIndex) + ']');
-    var $rights = $(this).closest('.diff').find('.diff-right').find('[line-no=' + (1+skipData.afterStartIndex) + ']');
-
-    if ($lefts.length == 2 && $rights.length == 2) {
-      var els = [$lefts.get(0), $lefts.get(1), $rights.get(0), $rights.get(1)];
-      for (var rowIdx = newRows.length - 1; rowIdx >= 0; rowIdx--) {
-        var row = newRows[rowIdx];
-        for (var i = 0; i < row.length; i++) {
-          $(els[i]).after(row[i]);
-        }
-      }
-      els.forEach(function(el) { $(el).remove(); });
-    }
+    var $skipTr = $(this).closest('tr');
+    $skipTr.replaceWith(newTrs);
   });
 };
 

--- a/codediff.js
+++ b/codediff.js
@@ -169,7 +169,7 @@ differ.prototype.buildRow_ = function(beforeIdx, beforeEnd, afterIdx, afterEnd, 
   afterIdx = addCells(els, afterIdx, afterEnd, this.params.language, afterLines, 'after', change, afterIdx + 1);
 
   if (change == 'replace') {
-    differ.addCharacterDiffs_(els[1], els[3], this.params.language);
+    differ.addCharacterDiffs_(els[1], els[2], this.params.language);
   }
 
   return {

--- a/codediff.js
+++ b/codediff.js
@@ -243,6 +243,9 @@ differ.prototype.buildView_ = function() {
 
   var $container = $('<div class="diff">');
   var $table = $('<table class="diff">');
+  $table.append($('<tr>').append(
+      $('<th class="diff-header" colspan=2>').text(this.params.beforeName),
+      $('<th class="diff-header" colspan=2>').text(this.params.afterName)));
 
   rows.forEach(function(row) {
     if (row.length != 3 && row.length != 4) {

--- a/codediff.js
+++ b/codediff.js
@@ -261,9 +261,11 @@ differ.prototype.buildView_ = function() {
   // Attach event handlers & apply char diffs.
   this.attachHandlers_($container);
 
-  $table.find('.code').each(function(_, el) {
-    differ.addSoftBreaks(el);
-  });
+  if (!this.params.wordWrap) {
+    $table.find('.code').each(function(_, el) {
+      differ.addSoftBreaks(el);
+    });
+  }
 
   return $container.get(0);
 };

--- a/codediff.js
+++ b/codediff.js
@@ -123,6 +123,8 @@ differ.prototype.attachHandlers_ = function(el) {
       newRows.push(data.row);
     }
 
+    console.log(newRows);
+
     // Replace the "skip" rows with real code.
     var $lefts = $(this).closest('.diff').find('.diff-left').find('[line-no=' + (1+skipData.beforeStartIndex) + ']');
     var $rights = $(this).closest('.diff').find('.diff-right').find('[line-no=' + (1+skipData.afterStartIndex) + ']');
@@ -160,64 +162,6 @@ differ.prototype.buildRow_ = function(beforeIdx, beforeEnd, afterIdx, afterEnd, 
   };
 };
 
-// Construct ranges of lines to show consecutively on either side.
-// The main work of this is factoring out ranges of common lines.
-// Output:
-// [ {change: "equal", left: { start, end }, right: { start, end }}, ... ]
-differ.prototype.buildRanges_ = function() {
-  var contextSize = this.params.contextSize;
-  var ranges = [];
-
-  for (var opcodeIdx = 0; opcodeIdx < this.opcodes.length; opcodeIdx++) {
-    var opcode = this.opcodes[opcodeIdx];
-    var change = opcode[0];  // "equal", "replace", "delete", "insert"
-    var beforeIdx = opcode[1];
-    var beforeEnd = opcode[2];
-    var afterIdx = opcode[3];
-    var afterEnd = opcode[4];
-    var rowCount = Math.max(beforeEnd - beforeIdx, afterEnd - afterIdx);
-    var topRows = [];
-    var botRows = [];
-
-    for (var i = 0; i < rowCount; i++) {
-      // Jump
-      if (contextSize && this.opcodes.length > 1 && change == 'equal' &&
-          ((opcodeIdx > 0 && i == contextSize) ||
-           (opcodeIdx == 0 && i == 0))) {
-        var jump = rowCount - ((opcodeIdx == 0 ? 1 : 2) * contextSize);
-        var isEnd = (opcodeIdx + 1 == this.opcodes.length);
-        if (isEnd) {
-          jump += (contextSize - 1);
-        }
-        if (jump > 1) {
-          ranges.push({
-            type: 'skip',
-            left: { start: beforeIdx, end: beforeIdx + jump },
-            right: { start: afterIdx, end: afterIdx + jump }
-          });
-
-          beforeIdx += jump;
-          afterIdx += jump;
-          i += jump - 1;
-
-          // skip last lines if they're all equal
-          if (isEnd) {
-            break;
-          } else {
-            continue;
-          }
-        }
-      }
-
-      var data = this.buildRow_(beforeIdx, beforeEnd, afterIdx, afterEnd, change);
-      beforeIdx = data.newBeforeIdx;
-      afterIdx = data.newAfterIdx;
-      topRows.push(data.row);
-    }
-  }
-
-  return ranges;
-};
 
 differ.prototype.buildView_ = function() {
   var contextSize = this.params.contextSize;
@@ -232,7 +176,6 @@ differ.prototype.buildView_ = function() {
     var afterEnd = opcode[4];
     var rowCount = Math.max(beforeEnd - beforeIdx, afterEnd - afterIdx);
     var topRows = [];
-    var botRows = [];
 
     for (var i = 0; i < rowCount; i++) {
       // Jump
@@ -280,7 +223,6 @@ differ.prototype.buildView_ = function() {
     }
 
     for (var i = 0; i < topRows.length; i++) rows.push(topRows[i]);
-    for (var i = 0; i < botRows.length; i++) rows.push(botRows[i]);
   }
 
   var $container = $('<div class="diff">');

--- a/test-mismatchedwidth.html
+++ b/test-mismatchedwidth.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html>
+<head>
+  <!-- A web font both looks nice and ensures consistent pixels across platforms.
+       It's not necessary for codediff.js to function, however. Any font will do. -->
+  <link href='http://fonts.googleapis.com/css?family=Inconsolata' rel='stylesheet' type='text/css'>
+  <link rel=stylesheet href="codediff.css">
+  <style>
+  .line-no, .code {
+    font-family: Courier;
+    font-size: small;
+  }
+  </style>
+
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+</head>
+<body>
+<p>Here's a sample diff rendered with codediff.js:</p>
+<div id="diffview">
+</div>
+
+<script src="difflib.js"></script>
+<script src="codediff.js"></script>
+<script type="text/javascript">
+function renderDiff(diffDiv, contentsBefore, contentsAfter) {
+  diffDiv.appendChild(codediff.buildView(contentsBefore, contentsAfter, {
+    beforeName: 'Short Rows',
+    afterName: 'Long Rows',
+    wordWrap: true
+  }));
+}
+</script>
+<script type="notjavascript" id="before">Hello
+Hello
+Hello
+Hello
+Hello
+Hello
+Hello
+Hello
+Hello
+to the World of Tomorrow
+Here's a line with a difference that's
+
+How's it going?
+
+I'm going to delete this.
+
+Line A
+Line B
+Line C
+Line D
+Line E
+Line F
+Line G
+Line H
+Line I
+Line J
+Line K
+Line L
+Line M
+Line N
+Line O
+Line P
+Line Q
+Line R
+Line S
+Line T
+Line U
+Line V
+Line W
+Line X
+Line Y
+Line Z
+</script>
+<script type="notjavascript" id="after">Hello
+Hello
+Hello
+Hello
+Hello
+Hello
+Hello
+Hello
+Hello
+to the Words of Tomorrow
+Here's a line with a difference that's "hard" to spot without char-by-char diffs
+
+How's it going?
+
+Line A
+Line B
+Line B2
+Line C
+Line D
+Line E
+Line F
+Line G
+Line H
+Line I
+Line J
+Line K
+> Line L2
+Line M
+Line N
+Line O
+Line Q
+Line R
+Line S
+Line T
+Line U
+Line V
+Line W
+Line X
+Line Y
+Line Z
+</script>
+
+<script type="text/javascript">
+var beforeText = $("#before").html();
+var afterText = $("#after").html();
+var diffDiv = $("#diffview").get(0);
+renderDiff(diffDiv, beforeText, afterText);
+</script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -18,5 +18,6 @@
   <script src="htmlsubstr_test.js"></script>
   <script src="addcharacterdiffs_test.js"></script>
   <script src="guesslanguage_test.js"></script>
+  <script src="softbreaks_test.js"></script>
 </body>
 </html>

--- a/test/softbreaks_test.js
+++ b/test/softbreaks_test.js
@@ -1,0 +1,7 @@
+QUnit.test('adds soft breaks to DOM', function(assert) {
+  var div = document.createElement('div');
+  div.innerHTML = 'foo<b>bar</b>baz';
+  codediff.addSoftBreaks(div);
+  var html = div.innerHTML.replace(/\u200B/g, '-');  // for legibility
+  assert.deepEqual('f-o-o<b>b-a-r</b>b-a-z', html);
+});


### PR DESCRIPTION
This makes use of [single-column selection][so] to preserve the ability to copy/paste text out of a diff.

Unfortunately, this completely breaks dpxdt, since PhantomJS supports neither soft breaks nor gradients.

Fixes #6 
Makes #7 possible without JavaScript.

[so]: http://stackoverflow.com/questions/6619805/select-text-in-a-column-of-an-html-table/27530627#27530627