### PR TITLE
Create a concept of "diff ranges" and add `minJumpSize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Here are possible keys you can pass through the options parameter:
 * `language`: Language to use for syntax highlighting. This parameter is passed through to highlight.js, which does the highlighting. Any value it will accept is fine. You can do `hljs.getLanguage(language)` to see if a language code is valid. A null value (the default) will disable syntax highlighting. Example values include "python" or "javascript". (default: _null_)
 * `beforeName`: Text to place above the left side of the diff.
 * `afterName`: Text to place above the right side of the diff.
-* `contextSize`: Minimum number of lines of context to show around each diff hunk. (default: _10_).
+* `contextSize`: Minimum number of lines of context to show around each diff hunk. (default: _3_).
+* `minJumpSize`: Minimum number of equal lines to collapse into a "Show N more lines" link. (default: _10_)
 * `wordWrap`: By default, code will go all the way to the right margin of the diff. If there are 60 characters of space, character 61 will wrap to the next line, even mid-word. To wrap at word boundaries instead, set this option.
 
 Here's an example usage with a filled-out options parameter:

--- a/test-mismatchedwidth.html
+++ b/test-mismatchedwidth.html
@@ -26,7 +26,8 @@ function renderDiff(diffDiv, contentsBefore, contentsAfter) {
   diffDiv.appendChild(codediff.buildView(contentsBefore, contentsAfter, {
     beforeName: 'Short Rows',
     afterName: 'Long Rows',
-    wordWrap: true
+    wordWrap: true,
+    minJumpSize: 0
   }));
 }
 </script>

--- a/test/diffranges_test.js
+++ b/test/diffranges_test.js
@@ -14,7 +14,7 @@ QUnit.test('generates same diff ranges as jsdifflib', function(assert) {
     ["equal",  32,43,30,41]
   ]
 
-  var ranges = codediff.opcodesToDiffRanges(opcodes, 3);
+  var ranges = codediff.opcodesToDiffRanges(opcodes, 3, 0);
   assert.deepEqual(ranges, [
     {type: 'skip',    before: [ 0, 6],  after: [ 0,  6]},
     {type: 'equal',   before: [ 6, 9],  after: [ 6,  9]},
@@ -30,6 +30,6 @@ QUnit.test('generates same diff ranges as jsdifflib', function(assert) {
     {type: 'equal',   before: [28, 31], after: [27, 30]},
     {type: 'delete',  before: [31, 32], after: [30, 30]},
     {type: 'equal',   before: [32, 35], after: [30, 33]},
-    {type: 'skip',    before: [35, 42], after: [33, 40]}
+    {type: 'skip',    before: [35, 43], after: [33, 41]}
   ]);
 });

--- a/test/diffranges_test.js
+++ b/test/diffranges_test.js
@@ -1,0 +1,35 @@
+QUnit.test('generates same diff ranges as jsdifflib', function(assert) {
+  // These are the opcodes for test.html
+  var opcodes = [
+    ["equal",   0, 9, 0, 9],
+    ["replace", 9,11, 9,11],
+    ["equal",  11,14,11,14],
+    ["delete", 14,16,14,14],
+    ["equal",  16,18,14,16],
+    ["insert", 18,18,16,17],
+    ["equal",  18,27,17,26],
+    ["replace",27,28,26,27],
+    ["equal",  28,31,27,30],
+    ["delete", 31,32,30,30],
+    ["equal",  32,43,30,41]
+  ]
+
+  var ranges = codediff.opcodesToDiffRanges(opcodes, 3);
+  assert.deepEqual(ranges, [
+    {type: 'skip',    before: [ 0, 6],  after: [ 0,  6]},
+    {type: 'equal',   before: [ 6, 9],  after: [ 6,  9]},
+    {type: 'replace', before: [ 9, 11], after: [ 9, 11]},
+    {type: 'equal',   before: [11, 14], after: [11, 14]},
+    {type: 'delete',  before: [14, 16], after: [14, 14]},
+    {type: 'equal',   before: [16, 18], after: [14, 16]},
+    {type: 'insert',  before: [18, 18], after: [16, 17]},
+    {type: 'equal',   before: [18, 21], after: [17, 20]},
+    {type: 'skip',    before: [21, 24], after: [20, 23]},
+    {type: 'equal',   before: [24, 27], after: [23, 26]},
+    {type: 'replace', before: [27, 28], after: [26, 27]},
+    {type: 'equal',   before: [28, 31], after: [27, 30]},
+    {type: 'delete',  before: [31, 32], after: [30, 30]},
+    {type: 'equal',   before: [32, 35], after: [30, 33]},
+    {type: 'skip',    before: [35, 42], after: [33, 40]}
+  ]);
+});

--- a/test/diffranges_test.js
+++ b/test/diffranges_test.js
@@ -49,4 +49,19 @@ QUnit.test('generates same diff ranges as jsdifflib', function(assert) {
     {type: 'equal',   before: [32, 35], after: [30, 33]},
     {type: 'skip',    before: [35, 43], after: [33, 41]}
   ]);
+
+  var ranges = codediff.opcodesToDiffRanges(opcodes, 3, 10);  // minJumpSize = 10
+  assert.deepEqual(ranges, [
+    {type: 'equal',   before: [ 0, 9],  after: [ 0,  9]},  // was skip
+    {type: 'replace', before: [ 9, 11], after: [ 9, 11]},
+    {type: 'equal',   before: [11, 14], after: [11, 14]},
+    {type: 'delete',  before: [14, 16], after: [14, 14]},
+    {type: 'equal',   before: [16, 18], after: [14, 16]},
+    {type: 'insert',  before: [18, 18], after: [16, 17]},
+    {type: 'equal',   before: [18, 27], after: [17, 26]},  // was skip
+    {type: 'replace', before: [27, 28], after: [26, 27]},
+    {type: 'equal',   before: [28, 31], after: [27, 30]},
+    {type: 'delete',  before: [31, 32], after: [30, 30]},
+    {type: 'equal',   before: [32, 43], after: [30, 41]}   // was skip
+  ]);
 });

--- a/test/diffranges_test.js
+++ b/test/diffranges_test.js
@@ -32,4 +32,21 @@ QUnit.test('generates same diff ranges as jsdifflib', function(assert) {
     {type: 'equal',   before: [32, 35], after: [30, 33]},
     {type: 'skip',    before: [35, 43], after: [33, 41]}
   ]);
+
+  var ranges = codediff.opcodesToDiffRanges(opcodes, 3, 5);  // minJumpSize = 5
+  assert.deepEqual(ranges, [
+    {type: 'skip',    before: [ 0, 6],  after: [ 0,  6]},
+    {type: 'equal',   before: [ 6, 9],  after: [ 6,  9]},
+    {type: 'replace', before: [ 9, 11], after: [ 9, 11]},
+    {type: 'equal',   before: [11, 14], after: [11, 14]},
+    {type: 'delete',  before: [14, 16], after: [14, 14]},
+    {type: 'equal',   before: [16, 18], after: [14, 16]},
+    {type: 'insert',  before: [18, 18], after: [16, 17]},
+    {type: 'equal',   before: [18, 27], after: [17, 26]},  // (eq-skip-eq above)
+    {type: 'replace', before: [27, 28], after: [26, 27]},
+    {type: 'equal',   before: [28, 31], after: [27, 30]},
+    {type: 'delete',  before: [31, 32], after: [30, 30]},
+    {type: 'equal',   before: [32, 35], after: [30, 33]},
+    {type: 'skip',    before: [35, 43], after: [33, 41]}
+  ]);
 });

--- a/test/index.html
+++ b/test/index.html
@@ -19,5 +19,6 @@
   <script src="addcharacterdiffs_test.js"></script>
   <script src="guesslanguage_test.js"></script>
   <script src="softbreaks_test.js"></script>
+  <script src="diffranges_test.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Previously the decision about skipping lines was tied in with the logic of generating the diff table. Now they're separate, which makes it easier to add nice options like `minJumpSize`.

Fixes #2 